### PR TITLE
feat: add clear chat button

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -211,6 +211,27 @@ with tab_chat:
 
         st.subheader("Chat Interface")
 
+        with st.popover(
+            "Clear Chat",
+            use_container_width=True
+        ):
+
+            st.warning(
+                "⚠️ Are you sure? "
+                "This will erase the chat history "
+                "but keep the knowledge graph intact."
+            )
+
+            if st.button(
+                "Yes, Clear Chat",
+                type="primary",
+                use_container_width=True
+            ):
+
+                st.session_state.messages = []
+
+                st.rerun()
+
         for msg in st.session_state.messages:
 
             with st.chat_message(msg["role"]):


### PR DESCRIPTION
Fixes #5。在 Chat 界面加了 Clear Chat 按钮,只清空对话记录、保留知识图谱,确认交互与现有 Reset Settings / Clear Everything 一致。验证: python -m py_compile app/app.py 通过。